### PR TITLE
change CloudWatch call to a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,8 +98,13 @@ exports.handler = function(event, context, callback) {
 			Namespace: event.namespace || "Watchtower",
 			MetricData: metricData,
         }
-        cloudwatch.putMetricData(params, (error, data) => {
-			callback(error, data)
+        return cloudwatch.putMetricData(params).promise()
+		.then(data => {
+			callback(null,data);
 		})
+		.catch(error => {
+			callback(error,null);
+		});
+
 	})
 }


### PR DESCRIPTION
This will change the CloudWatch method call to a promise, which will make Lambda wait for the CloudWatch response to resolve before it finishes the Lambda function