### PR TITLE
Upper limit of CloudWatch method call fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Logs are stored as AWS CloudWatch metrics.
     {
       "url": "https://example.org",
       "name": "example.org", //Optional, defaults to url; Display name of the target
-	  "protocol": "http/s"
+      "type": "http/s"
     },
-	{
-	  "url": "mailserver.example.org",
-	  "name": "Mailserver SMTP port check",
-	  "protocol": "port",
-	  "port": 25
+    {
+      "url": "mailserver.example.org",
+      "name": "Mailserver SMTP port check",
+      "type": "tcp",
+      "port": 25
 	}
   ],
   "namespace": "Watchtower", //Optional, defaults to "Watchtower"; CloudWatch namespace

--- a/index.js
+++ b/index.js
@@ -10,19 +10,30 @@ const hrDiff = (start, end) => hrToMs(end) - hrToMs(start)
 const timingsDiff = (timings, key1, key2) => timings[key1] && timings[key2] && hrDiff(timings[key1], timings[key2])
 
 const processTimings = function(timings) {
-	return {
-		lookup: timingsDiff(timings, "start", "lookup"),
-		connect: timingsDiff(timings, "lookup", "connect"), 
-		secureConnect: timingsDiff(timings, "connect", "secureConnect"),
-		readable: timingsDiff(timings, "secureConnect", "readable") || timingsDiff(timings, "connect", "readable"),
+    return {
+        lookup: timingsDiff(timings, "start", "lookup"),
+        connect: timingsDiff(timings, "lookup", "connect"), 
+        secureConnect: timingsDiff(timings, "connect", "secureConnect"),
+        readable: timingsDiff(timings, "secureConnect", "readable") || timingsDiff(timings, "connect", "readable"),
         close: timingsDiff(timings, "readable", "close"),
         total: timingsDiff(timings, "start", "close")
-	}
+    }
 }
 
 const createRequest = function(url, callback) {
     const handler = url.startsWith("http://") ? http : https
     return handler.get(url, callback)
+}
+
+const ArrayChunk = function (arr, len) {
+
+  var chunks = [], i = 0, n = arr.length;
+
+  while (i < n) {
+    chunks.push(arr.slice(i, i += len));
+  }
+
+  return chunks;
 }
 
 /**
@@ -40,92 +51,92 @@ exports.handler = function(event, context, callback) {
     const targets = event.targets
     if (!targets) callback("No targets given")
 
-	const requests = targets.map(target => new Promise((resolve, reject) => {
-		const data = {
+    const requests = targets.map(target => new Promise((resolve, reject) => {
+        const data = {
             name: target.name || target.url,
             timings: {
                 start: hrtime()
             }
         }
-		if(target.protocol === undefined || target.protocol === 'http/s') {
-			const request = createRequest(target.url, response => {
-				data.statusCode = response.statusCode
-				response.once("readable", () => data.timings.readable = hrtime())
-				response.once("end", () => data.timings.end = hrtime())
-			})
-			request.setTimeout(1)
-			const timeout = setTimeout(() => request.abort(), event.timeout || 2000)
-			request.on("socket", socket => {
-				socket.on("lookup", () => data.timings.lookup = hrtime())
-				socket.on("connect", () => data.timings.connect = hrtime())
-				socket.on("secureConnect", () => data.timings.secureConnect = hrtime())
-			})
-			request.on("close", () => {
-				data.timings.close = hrtime()
-				data.durations = processTimings(data.timings)
-				clearTimeout(timeout)
-				resolve(data)
-			})
-			request.on("error", () => {
-				data.timings.close = hrtime()
-				data.durations = processTimings(data.timings)
-				data.statusCode = typeof data.statusCode !== "undefined" ? data.statusCode : 0
-				clearTimeout(timeout)
-				resolve(data)
-			})
-		} else if (target.protocol === 'port') {
-			
-			if(target.url.startsWith('http://') || target.url.startsWith('https://')){
-				reject("http url for non http check")
-			}
-			
-			const socket = new net.Socket()
+        if(target.type === undefined || target.type === 'http/s') {
+            const request = createRequest(target.url, response => {
+                data.statusCode = response.statusCode
+                response.once("readable", () => data.timings.readable = hrtime())
+                response.once("end", () => data.timings.end = hrtime())
+            })
+            request.setTimeout(1)
+            const timeout = setTimeout(() => request.abort(), event.timeout || 2000)
+            request.on("socket", socket => {
+                socket.on("lookup", () => data.timings.lookup = hrtime())
+                socket.on("connect", () => data.timings.connect = hrtime())
+                socket.on("secureConnect", () => data.timings.secureConnect = hrtime())
+            })
+            request.on("close", () => {
+                data.timings.close = hrtime()
+                data.durations = processTimings(data.timings)
+                clearTimeout(timeout)
+                resolve(data)
+            })
+            request.on("error", () => {
+                data.timings.close = hrtime()
+                data.durations = processTimings(data.timings)
+                data.statusCode = typeof data.statusCode !== "undefined" ? data.statusCode : 0
+                clearTimeout(timeout)
+                resolve(data)
+            })
+        } else if (target.type === 'tcp') {
+            
+            if(target.url.startsWith('http://') || target.url.startsWith('https://')){
+                reject("http url for non http check")
+            }
+            
+            const socket = new net.Socket()
 
-			socket.setTimeout(event.timeout || 2000);
+            socket.setTimeout(event.timeout || 2000);
 
-			socket.on('connect',() => {
-				data.timings.connect = hrtime()
-			})
-			socket.on('lookup',() => {
-				data.timings.lookup = hrtime()
-			})
-			socket.on('data',() => {
-				data.timings.readable = hrtime()
-				socket.end();
-			})
-			socket.on('end',() => {
-				data.timings.end = hrtime()
-			})
-			socket.on('error',() => {
-				data.timings.close = hrtime()
-				data.durations = processTimings(data.timings)
-				data.statusCode = -1
-				socket.destroy()
-				resolve(data)
-			});
-			socket.on('timeout', () => {
-				data.timings.close = hrtime()
-				data.durations = processTimings(data.timings)
-				data.statusCode = -1
-				socket.destroy()
-				resolve(data)
-			});
-			socket.on('close', () => {
-				data.timings.close = hrtime()
-				data.durations = processTimings(data.timings)
-				data.statusCode = 0
-				socket.destroy()
-				resolve(data)
-			})
+            socket.on('connect',() => {
+                data.timings.connect = hrtime()
+            })
+            socket.on('lookup',() => {
+                data.timings.lookup = hrtime()
+            })
+            socket.on('data',() => {
+                data.timings.readable = hrtime()
+                socket.end();
+            })
+            socket.on('end',() => {
+                data.timings.end = hrtime()
+            })
+            socket.on('error',() => {
+                data.timings.close = hrtime()
+                data.durations = processTimings(data.timings)
+                data.statusCode = -1
+                socket.destroy()
+                resolve(data)
+            });
+            socket.on('timeout', () => {
+                data.timings.close = hrtime()
+                data.durations = processTimings(data.timings)
+                data.statusCode = -1
+                socket.destroy()
+                resolve(data)
+            });
+            socket.on('close', () => {
+                data.timings.close = hrtime()
+                data.durations = processTimings(data.timings)
+                data.statusCode = 0
+                socket.destroy()
+                resolve(data)
+            })
 
-			socket.connect(target.port, target.url, () => {
-			});
-			
-			
-		}
-	}))
+            socket.connect(target.port, target.url, () => {
+            });
+            
+            
+        }
+    }))
     
-	return Promise.all(requests).then(results => {
+    return Promise.all(requests).then(results => {
         const timestamp = new Date()
         const includedTimings = event.logTimings || ["readable", "total"]
         const metricData = results.map(result => {


### PR DESCRIPTION
So I didnt realize you were using spaces instead of tabs, this will fix (my bad)

Also when there are multiple checks (greater than 5 I found) CloudWatch has a upper limit on the number of metrics you can send with each call, so the calls start failing. This will chunk the metric array and send as separate method calls.

I suppose it also depends on what specific timing metrics you are sending into CloudWatch as well - but the logic is looking at the full metric array, so it will scale with more check endpoints.


I also changed the values you suggested