### PR TITLE
workaround for node.js bug https://github.com/nodejs/node/issues/21398

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,10 @@ Check handler for HTTP(S)
 handlers.http = (target, data, event, resolve, reject) => {
     const request = createRequest(target.url, response => {
         data.statusCode = response.statusCode
-        response.once("readable", () => data.timings.readable = hrtime())
+        response.once("readable", () => {
+            data.timings.readable = hrtime()
+            response.on('data', () => { })
+        })
         response.once("end", () => data.timings.end = hrtime())
     })
     request.setTimeout(1)
@@ -245,3 +248,4 @@ handlers.smtp = (target, data, event, resolve, reject) => {
     socket.connect(target.port, target.hostname, () => {})
 
 }
+


### PR DESCRIPTION
There's a bug in the version of Node.js 10.x that Lambda uses that causes the http request 'end' event to not be fired. see https://github.com/nodejs/node/issues/21398

This results in the "close" and therefore "total" timings to be the timeout value, instead of the actual URL load end value. Example graph (with calculated items to change from milliseconds to seconds) shows the results for www.google.com as I adjusted the timeout values: 6s, 10s, 30s, 60s.

![google-timeouts](https://user-images.githubusercontent.com/2607526/64441237-186bd200-d093-11e9-98e2-831f9c49dcf9.png)

Workaround listed on the nodejs issues page applied to this code fixes the problem.