### PR TITLE
http: actively read and discard response data on every 'readable' event.

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,7 @@ handlers.http = (target, data, event, resolve, reject) => {
     const request = createRequest(target.url, response => {
         data.statusCode = response.statusCode
         response.once("readable", () => data.timings.readable = hrtime())
+        response.on("readable", () => response.read()) // discard the response buffer
         response.once("end", () => data.timings.end = hrtime())
     })
     request.setTimeout(1)


### PR DESCRIPTION
Per Node documentation, any response (http.IncomingMessage -> stream.Readable)
must be fully consumed. Otherwise, reading data will block, once the internal
buffer is full.

Effectively this caused http targets with a large enough response body to
always run until the configured timeout is reached.

This also causes the 'end' event not to fire.

References:

- https://nodejs.org/docs/latest-v10.x/api/stream.html#stream_buffering:
  "Once the total size of the internal read buffer reaches the threshold
  specified by highWaterMark, the stream will temporarily stop reading data
  from the underlying resource until the data currently buffered can be
  consumed"

- https://nodejs.org/docs/latest-v10.x/api/stream.html#stream_event_end:
  "The 'end' event will not be emitted unless the data is completely consumed."

Fixes #11.